### PR TITLE
Use UnixNano() for more precision in rand seeding

### DIFF
--- a/pairing-bot.go
+++ b/pairing-bot.go
@@ -659,7 +659,7 @@ func endofbatch(w http.ResponseWriter, r *http.Request) {
 // TODO: source of randomness is time, but this runs at the
 // same time each day. Is that ok?
 func shuffle(slice []map[string]interface{}) []map[string]interface{} {
-	r := rand.New(rand.NewSource(time.Now().Unix()))
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	ret := make([]map[string]interface{}, len(slice))
 	perm := r.Perm(len(slice))
 	for i, randIndex := range perm {


### PR DESCRIPTION
As [this comment](https://github.com/thwidge/pairing-bot/blob/main/pairing-bot.go#L659) points out, the fact that matches are always made at the same time of day might affect the source of randomness for shuffling the list of users.

Try using `UnixNano()` which should provide more precision than `Unix()` and thus more variation of the value used as the seed for `rand`.

Alternatively, the [crypto/rand](https://golang.org/pkg/crypto/rand/) package could be used to generate a seed that's not based on time, [like so](https://stackoverflow.com/a/54491783/5773867).

It would be cool to have a way of validating whether this potential change actually has an effect on the randomness of the pairings! I wonder if it would make sense to temporarily add logging for this purpose (logging the matches actually generated by the bot for some consecutive days), what do you think @thwidge ?