### PR TITLE
Refactor RecursersClient.Set to use the recurser ID

### DIFF
--- a/dispatch.go
+++ b/dispatch.go
@@ -71,7 +71,7 @@ func (pl *PairingLogic) SetSchedule(ctx context.Context, rec *store.Recurser, da
 
 	rec.Schedule = store.NewSchedule(days)
 
-	if err := store.Recursers(pl.db).Set(ctx, rec.ID, rec); err != nil {
+	if err := store.Recursers(pl.db).Set(ctx, rec); err != nil {
 		return writeErrorMessage, err
 	}
 	return "Awesome, your new schedule's been set! You can check it with `status`.", nil
@@ -90,7 +90,7 @@ func (pl *PairingLogic) Subscribe(ctx context.Context, rec *store.Recurser) (str
 
 	rec.CurrentlyAtRC = atRC
 
-	if err = store.Recursers(pl.db).Set(ctx, rec.ID, rec); err != nil {
+	if err = store.Recursers(pl.db).Set(ctx, rec); err != nil {
 		log.Printf("Could not update recurser in database: %s", err)
 		return writeErrorMessage, err
 	}
@@ -115,7 +115,7 @@ func (pl *PairingLogic) SkipTomorrow(ctx context.Context, rec *store.Recurser) (
 
 	rec.IsSkippingTomorrow = true
 
-	if err := store.Recursers(pl.db).Set(ctx, rec.ID, rec); err != nil {
+	if err := store.Recursers(pl.db).Set(ctx, rec); err != nil {
 		return writeErrorMessage, err
 	}
 	return `Tomorrow: cancelled. I feel you. **I will not match you** for pairing tomorrow <3`, nil
@@ -127,7 +127,7 @@ func (pl *PairingLogic) UnskipTomorrow(ctx context.Context, rec *store.Recurser)
 	}
 	rec.IsSkippingTomorrow = false
 
-	if err := store.Recursers(pl.db).Set(ctx, rec.ID, rec); err != nil {
+	if err := store.Recursers(pl.db).Set(ctx, rec); err != nil {
 		return writeErrorMessage, err
 	}
 	return "Tomorrow: uncancelled! Heckin *yes*! **I will match you** for pairing tomorrow :)", nil

--- a/pairing_bot.go
+++ b/pairing_bot.go
@@ -250,7 +250,7 @@ func (pl *PairingLogic) EndOfBatch(ctx context.Context) error {
 
 		recurser.CurrentlyAtRC = isAtRCThisWeek
 
-		if err = store.Recursers(pl.db).Set(ctx, recurser.ID, recurser); err != nil {
+		if err = store.Recursers(pl.db).Set(ctx, recurser); err != nil {
 			log.Printf("Error encountered while update currentlyAtRC status for user: %s (ID %d)", recurser.Name, recurser.ID)
 		}
 

--- a/store/recursers.go
+++ b/store/recursers.go
@@ -111,7 +111,7 @@ func (r *RecursersClient) GetAllUsers(ctx context.Context) ([]Recurser, error) {
 	return fetchAll[Recurser](iter)
 }
 
-func (r *RecursersClient) Set(ctx context.Context, _ int64, recurser *Recurser) error {
+func (r *RecursersClient) Set(ctx context.Context, recurser *Recurser) error {
 	docID := strconv.FormatInt(recurser.ID, 10)
 
 	// Merging isn't supported when using struct data, but we never do partial
@@ -153,5 +153,5 @@ func (r *RecursersClient) ListSkippingTomorrow(ctx context.Context) ([]Recurser,
 
 func (r *RecursersClient) UnsetSkippingTomorrow(ctx context.Context, recurser *Recurser) error {
 	recurser.IsSkippingTomorrow = false
-	return r.Set(ctx, recurser.ID, recurser)
+	return r.Set(ctx, recurser)
 }

--- a/store/recursers_test.go
+++ b/store/recursers_test.go
@@ -27,7 +27,7 @@ func TestFirestoreRecursersClient(t *testing.T) {
 			CurrentlyAtRC:      false,
 		}
 
-		err := recursers.Set(ctx, recurser.ID, &recurser)
+		err := recursers.Set(ctx, &recurser)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,4 +75,3 @@ func TestFirestoreRecursersClient(t *testing.T) {
 		assert.Equal(t, actual, recurser)
 	})
 }
-


### PR DESCRIPTION
## Summary
- remove the redundant `userID` argument from `RecursersClient.Set`
- derive the Firestore document ID from `recurser.ID`
- update all production and test call sites

## Validation
- `go build ./...`
- `go vet ./...`
- `go test .` with `FIRESTORE_EMULATOR_HOST` configured
- `go test ./recurse ./zulip`
- `go test ./store -run '^$'` (compiles the Firestore test package locally; the full emulator-backed suite runs in CI)

Fixes #117